### PR TITLE
Add  forall atom/term to Prover and Proof

### DIFF
--- a/lib/Parser/Parser.ml
+++ b/lib/Parser/Parser.ml
@@ -105,7 +105,21 @@ let rec pformula_to_formula env = function
       let env'' = (fix_name, K_FVar (fix_i, fix_k)) :: env' in
       F_Fix (FV_Bind (fix_name, fix_i, fix_k), V x, k, pformula_to_formula env'' f)
 
-let parse_term s = pterm_to_term [] $ parse term s
+let parse_atom_in_env env s =
+  let raise_not_an_atom_but what =
+    let exn = Printf.sprintf "Expected %s to be an atom, not a %s" s what in
+    raise $ ParserException exn
+  in
+  let a = parse identifier s in
+  match List.assoc_opt a env with
+  | Some K_Atom     -> A a
+  | Some K_Var      -> raise_not_an_atom_but "variable"
+  | Some (K_FVar _) -> raise_not_an_atom_but "logical variable"
+  | None            -> raise $ unbound_variable a
+
+let parse_term_in_env env s = pterm_to_term env $ parse term s
+
+let parse_term = parse_term_in_env []
 
 let parse_constr_in_env env s = pconstr_to_constr env $ parse constr s
 

--- a/lib/Proof/Proof.ml
+++ b/lib/Proof/Proof.ml
@@ -3,6 +3,7 @@ open Common
 open ProofCommon
 open ProofEnv
 open ProofException
+open Substitution
 open Utils
 
 type proof_env = formula env
@@ -10,13 +11,13 @@ type proof_env = formula env
 type judgement = proof_env * formula
 
 type proof =
-  | P_Ax          of judgement
-  | P_Intro       of judgement * proof
-  | P_Apply       of judgement * proof * proof
-  | P_ConstrIntro of judgement * proof
-  | P_ConstrApply of judgement * proof * proof
-  | P_SpecifyAtom of judgement * atom * proof
-  | P_ExFalso     of judgement * proof
+  | P_Ax             of judgement
+  | P_Intro          of judgement * proof
+  | P_Apply          of judgement * proof * proof
+  | P_ConstrIntro    of judgement * proof
+  | P_ConstrApply    of judgement * proof * proof
+  | P_SpecializeAtom of judgement * atom * proof
+  | P_ExFalso        of judgement * proof
 
 let label = function
   | P_Ax (_, f)
@@ -24,7 +25,7 @@ let label = function
   | P_Apply ((_, f), _, _)
   | P_ConstrIntro ((_, f), _)
   | P_ConstrApply ((_, f), _, _)
-  | P_SpecifyAtom ((_, f), _, _)
+  | P_SpecializeAtom ((_, f), _, _)
   | P_ExFalso ((_, f), _) -> f
 
 let env = function
@@ -33,12 +34,12 @@ let env = function
   | P_Apply ((e, _), _, _)
   | P_ConstrIntro ((e, _), _)
   | P_ConstrApply ((e, _), _, _)
-  | P_SpecifyAtom ((e, _), _, _)
+  | P_SpecializeAtom ((e, _), _, _)
   | P_ExFalso ((e, _), _) -> e
 
 let judgement proof = (env proof, label proof)
 
-let by_assumption identifiers f = P_Ax (ProofEnv.env identifiers [] [f], f)
+let axiom identifiers f = P_Ax (ProofEnv.env identifiers [] [f], f)
 
 let remove_assumption f = remove_assumptions (equiv f)
 
@@ -88,16 +89,16 @@ let find_bind name env =
   | Some f -> Some f
   | None   -> to_formula <$> List.find_opt bound_in_constr (constraints env)
 
-let uni_atom_i (A a) p =
+let forall_atom_i (A a) p =
   let env, f = judgement p in
   match env |> find_bind a with
   | None   -> P_Intro ((env |> remove_atom a, F_ForallAtom (A a, f)), p)
   | Some f -> raise $ cannot_generalize a f
 
-let uni_atom_e (A b) p =
+let forall_atom_e (A b) p =
   match label p with
   | F_ForallAtom (a, f) ->
       let env = add_atom b $ env p in
-      let f = Substitution.subst_atom_in_formula a (A b) f in
-      P_SpecifyAtom ((env, f), a, p)
+      let f = (a |-> A b) f in
+      P_SpecializeAtom ((env, f), a, p)
   | f                   -> raise $ not_a_forall f

--- a/lib/Proof/Proof.mli
+++ b/lib/Proof/Proof.mli
@@ -12,6 +12,7 @@ type proof = private
   | P_ConstrIntro    of judgement * proof
   | P_ConstrApply    of judgement * proof * proof
   | P_SpecializeAtom of judgement * atom * proof
+  | P_SpecializeTerm of judgement * term * proof
   | P_ExFalso        of judgement * proof
 
 val label : proof -> formula
@@ -37,3 +38,7 @@ val constr_imp_e : proof -> proof -> proof
 val forall_atom_i : atom -> proof -> proof
 
 val forall_atom_e : atom -> proof -> proof
+
+val forall_term_i : var -> proof -> proof
+
+val forall_term_e : term -> proof -> proof

--- a/lib/Proof/Proof.mli
+++ b/lib/Proof/Proof.mli
@@ -33,3 +33,5 @@ val constr_i : proof_env -> constr -> proof
 val constr_imp_i : constr -> proof -> proof
 
 val constr_imp_e : proof -> proof -> proof
+
+val uni_atom_i : atom -> proof -> proof

--- a/lib/Proof/Proof.mli
+++ b/lib/Proof/Proof.mli
@@ -5,15 +5,14 @@ type proof_env = formula env
 
 type judgement = proof_env * formula
 
-(** For ease of development it is defined here, but in future it will be abstract *)
-type proof =
-  | P_Ax          of judgement
-  | P_Intro       of judgement * proof
-  | P_Apply       of judgement * proof * proof
-  | P_ConstrIntro of judgement * proof
-  | P_ConstrApply of judgement * proof * proof
-  | P_SpecifyAtom of judgement * atom * proof
-  | P_ExFalso     of judgement * proof
+type proof = private
+  | P_Ax             of judgement
+  | P_Intro          of judgement * proof
+  | P_Apply          of judgement * proof * proof
+  | P_ConstrIntro    of judgement * proof
+  | P_ConstrApply    of judgement * proof * proof
+  | P_SpecializeAtom of judgement * atom * proof
+  | P_ExFalso        of judgement * proof
 
 val label : proof -> formula
 
@@ -21,7 +20,7 @@ val env : proof -> proof_env
 
 val judgement : proof -> judgement
 
-val by_assumption : identifier_env -> formula -> proof
+val axiom : identifier_env -> formula -> proof
 
 val imp_i : formula -> proof -> proof
 
@@ -35,6 +34,6 @@ val constr_imp_i : constr -> proof -> proof
 
 val constr_imp_e : proof -> proof -> proof
 
-val uni_atom_i : atom -> proof -> proof
+val forall_atom_i : atom -> proof -> proof
 
-val uni_atom_e : atom -> proof -> proof
+val forall_atom_e : atom -> proof -> proof

--- a/lib/Proof/Proof.mli
+++ b/lib/Proof/Proof.mli
@@ -10,9 +10,10 @@ type proof =
   | P_Ax          of judgement
   | P_Intro       of judgement * proof
   | P_Apply       of judgement * proof * proof
-  | P_ExFalso     of judgement * proof
   | P_ConstrIntro of judgement * proof
   | P_ConstrApply of judgement * proof * proof
+  | P_SpecifyAtom of judgement * atom * proof
+  | P_ExFalso     of judgement * proof
 
 val label : proof -> formula
 
@@ -35,3 +36,5 @@ val constr_imp_i : constr -> proof -> proof
 val constr_imp_e : proof -> proof -> proof
 
 val uni_atom_i : atom -> proof -> proof
+
+val uni_atom_e : atom -> proof -> proof

--- a/lib/Proof/ProofCommon.ml
+++ b/lib/Proof/ProofCommon.ml
@@ -1,5 +1,6 @@
 open Common
 open ProofException
+open Substitution
 open Types
 
 let to_constr_op = function
@@ -20,8 +21,32 @@ let conclusion = function
   | F_Impl (_, c) | F_ConstrImpl (_, c) -> c
   | f -> raise $ not_an_implication f
 
-let equiv (f1 : formula) (f2 : formula) = f1 = f2
+let rec equiv f1 f2 =
+  match (f1, f2) with
+  | F_Top, F_Top | F_Bot, F_Bot -> true
+  | F_Top, _ | F_Bot, _ -> false
+  | F_Var x1, F_Var x2 -> x1 = x2
+  | F_Var _, _ -> false
+  | F_And f1s, F_And f2s | F_Or f1s, F_Or f2s -> List.for_all2 equiv f1s f2s
+  | F_And _, _ | F_Or _, _ -> false
+  | F_Constr c1, F_Constr c2 -> c1 = c2
+  | F_Constr _, _ -> false
+  | F_ConstrImpl (c1, f1), F_ConstrImpl (c2, f2) -> c1 = c2 && f1 === f2
+  | F_ConstrImpl _, _ -> false
+  | F_Impl (f1, f1'), F_Impl (f2, f2') -> f1 === f2 && f1' === f2'
+  | F_Impl _, _ -> false
+  | F_ForallAtom (a1, f1), F_ForallAtom (a2, f2) ->
+      let a = fresh_atom () in
+      (a1 |-> a) f1 === (a2 |-> a) f2
+  | F_ForallTerm (x1, f1), F_ForallTerm (x2, f2) ->
+      let x = var (fresh_var ()) in
+      (x1 |=> x) f1 === (x2 |=> x) f2
+  | F_ForallAtom _, _ -> false
+  | _ ->
+      failwith
+      $ Printf.sprintf "unimplemented: %s === %s" (Printing.string_of_formula f1)
+          (Printing.string_of_formula f2)
 
-let ( === ) = equiv
+and ( === ) f1 f2 = equiv f1 f2
 
 let ( =/= ) = not %% ( === )

--- a/lib/Proof/ProofEnv.ml
+++ b/lib/Proof/ProofEnv.ml
@@ -38,11 +38,13 @@ let union
     {assumptions= a2; identifiers= i2; constraints= c2} =
   {assumptions= merge a1 a2; identifiers= merge i1 i2; constraints= merge c1 c2}
 
-let add_fvar x_name x_rep x_kind = on_identifiers (List.cons (x_name, K_FVar (x_rep, x_kind)))
+let add_fvar x_name x_rep x_kind = on_identifiers $ merge [(x_name, K_FVar (x_rep, x_kind))]
+
+let add_atom a = on_identifiers $ merge [(a, K_Atom)]
 
 let add_constr constr = on_constraints (List.cons constr)
 
-let add_assumption item = union (singleton item)
+let add_assumption ass = on_assumptions $ merge [ass]
 
 let map_assumptions f = on_assumptions (List.map f)
 
@@ -53,6 +55,8 @@ let unfilter test = List.filter (not % test)
 let remove_assumptions test = on_assumptions $ unfilter test
 
 let remove_constraints test = on_constraints $ unfilter test
+
+let remove_identifiers test = on_identifiers $ unfilter test
 
 let kind_checker_env {identifiers; _} =
   let add_identifier env = function

--- a/lib/Proof/ProofEnv.ml
+++ b/lib/Proof/ProofEnv.ml
@@ -58,6 +58,12 @@ let remove_constraints test = on_constraints $ unfilter test
 
 let remove_identifiers test = on_identifiers $ unfilter test
 
+let remove_atom a =
+  remove_identifiers
+  $ function
+  | b, K_Atom -> a = b
+  | _         -> false
+
 let kind_checker_env {identifiers; _} =
   let add_identifier env = function
     | x_name, K_FVar (x, k) -> KindCheckerEnv.map_fvar env x_name (FV x) k

--- a/lib/Proof/ProofEnv.mli
+++ b/lib/Proof/ProofEnv.mli
@@ -20,6 +20,8 @@ val union : 'a env -> 'a env -> 'a env
 
 val add_fvar : string -> int -> kind -> 'a env -> 'a env
 
+val add_atom : string -> 'a env -> 'a env
+
 val add_constr : constr -> 'a env -> 'a env
 
 val add_assumption : 'a -> 'a env -> 'a env
@@ -31,6 +33,8 @@ val lookup_assumption : ('a -> bool) -> 'a env -> 'a option
 val remove_assumptions : ('a -> bool) -> 'a env -> 'a env
 
 val remove_constraints : (constr -> bool) -> 'a env -> 'a env
+
+val remove_identifiers : (identifier -> bool) -> 'a env -> 'a env
 
 val kind_checker_env : 'a env -> KindCheckerEnv.t
 

--- a/lib/Proof/ProofEnv.mli
+++ b/lib/Proof/ProofEnv.mli
@@ -22,7 +22,7 @@ val add_fvar : string -> int -> kind -> 'a env -> 'a env
 
 val add_atom : string -> 'a env -> 'a env
 
-val remove_atom : string -> 'a env -> 'a env
+val remove_identifier : string -> 'a env -> 'a env
 
 val add_constr : constr -> 'a env -> 'a env
 
@@ -32,6 +32,8 @@ val map_assumptions : ('a -> 'b) -> 'a env -> 'b env
 
 val lookup_assumption : ('a -> bool) -> 'a env -> 'a option
 
+val lookup_identifier : string -> 'a env -> identifier option
+
 val remove_assumptions : ('a -> bool) -> 'a env -> 'a env
 
 val remove_constraints : (constr -> bool) -> 'a env -> 'a env
@@ -39,5 +41,7 @@ val remove_constraints : (constr -> bool) -> 'a env -> 'a env
 val remove_identifiers : (identifier -> bool) -> 'a env -> 'a env
 
 val kind_checker_env : 'a env -> KindCheckerEnv.t
+
+val find_bind : ('a -> formula) -> string -> 'a env -> formula option
 
 val pp_print_env : 'a printer -> 'a env printer

--- a/lib/Proof/ProofEnv.mli
+++ b/lib/Proof/ProofEnv.mli
@@ -22,6 +22,8 @@ val add_fvar : string -> int -> kind -> 'a env -> 'a env
 
 val add_atom : string -> 'a env -> 'a env
 
+val remove_atom : string -> 'a env -> 'a env
+
 val add_constr : constr -> 'a env -> 'a env
 
 val add_assumption : 'a -> 'a env -> 'a env

--- a/lib/Proof/ProofException.ml
+++ b/lib/Proof/ProofException.ml
@@ -25,6 +25,8 @@ let not_a_constr_implication = not_what_expected "a constraint implication" % st
 
 let not_a_constraint = not_what_expected "a constraint" % string_of_formula
 
+let not_a_forall = not_what_expected "an universal quantification" % string_of_formula
+
 let premise_mismatch hypothesis premise =
   not_what_expected
     ("implication with premise " ^ string_of_formula premise)
@@ -47,6 +49,7 @@ let solver_failure constraints constr =
   let exn = Printf.sprintf "Solver cannot solve %s |- %s" constrs' constr' in
   ProofException exn
 
-let cannot_generalize name =
-  let exn = Printf.sprintf "Cannot generalize %s as it is bound in environment" name in
+let cannot_generalize name f =
+  let f = string_of_formula f in
+  let exn = Printf.sprintf "Cannot generalize %s as it is bound in %s" name f in
   ProofException exn

--- a/lib/Proof/ProofException.ml
+++ b/lib/Proof/ProofException.ml
@@ -46,3 +46,7 @@ let solver_failure constraints constr =
   let constr' = string_of_constr constr in
   let exn = Printf.sprintf "Solver cannot solve %s |- %s" constrs' constr' in
   ProofException exn
+
+let cannot_generalize name =
+  let exn = Printf.sprintf "Cannot generalize %s as it is bound in environment" name in
+  ProofException exn

--- a/lib/Prover/IncProof.ml
+++ b/lib/Prover/IncProof.ml
@@ -62,7 +62,11 @@ let rec normalize incproof =
 
 and proof_intro jgmt conclusion_proof =
   match normalize conclusion_proof with
-  | PI_Proven proof -> proven (imp_i (premise $ snd jgmt) proof)
+  | PI_Proven proof -> (
+    match snd jgmt with
+    | F_Impl (premise, _) -> proven $ imp_i premise proof
+    | F_ForallAtom (a, _) -> proven $ uni_atom_i a proof
+    | f                   -> raise $ not_an_implication f )
   | incproof        -> PI_Intro (jgmt, incproof)
 
 and proof_constr_intro jgmt conclusion_proof =

--- a/lib/Prover/Prover.ml
+++ b/lib/Prover/Prover.ml
@@ -89,5 +89,5 @@ let qed = finish
 let generalize a state =
   let env, f = goal state in
   let g = F_ForallAtom (A a, f) in
-  let context = PC_SpecifyAtom (to_judgement (env, f), A a, context state) in
+  let context = PC_SpecializeAtom (to_judgement (env, f), A a, context state) in
   unfinished (env |> remove_atom a, g) context

--- a/lib/Prover/Prover.ml
+++ b/lib/Prover/Prover.ml
@@ -85,3 +85,9 @@ let by_solver state =
   | f          -> raise $ not_a_constraint f
 
 let qed = finish
+
+let generalize a state =
+  let env, f = goal state in
+  let g = F_ForallAtom (A a, f) in
+  let context = PC_SpecifyAtom (to_judgement (env, f), A a, context state) in
+  unfinished (env |> remove_atom a, g) context

--- a/lib/Prover/Prover.mli
+++ b/lib/Prover/Prover.mli
@@ -5,9 +5,9 @@ open Types
 
 val proof : goal_env -> formula -> prover_state
 
-val intro : string -> tactic
+val intro : tactic
 
-val intro_constr : tactic
+val intro_named : string -> tactic
 
 val apply : formula -> tactic
 

--- a/lib/Prover/Prover.mli
+++ b/lib/Prover/Prover.mli
@@ -15,6 +15,8 @@ val apply_thm : proof -> tactic
 
 val apply_assm : string -> tactic
 
+val apply_assm_specialized : string -> string list -> tactic
+
 val by_solver : tactic
 
 val ex_falso : tactic

--- a/lib/Prover/Prover.mli
+++ b/lib/Prover/Prover.mli
@@ -22,3 +22,5 @@ val ex_falso : tactic
 val truth : tactic
 
 val qed : prover_state -> proof
+
+val generalize : string -> tactic

--- a/lib/Prover/ProverInternals.ml
+++ b/lib/Prover/ProverInternals.ml
@@ -35,7 +35,8 @@ and find_goal_in_ctx incproof = function
   | PC_ConstrIntro (jgmt, ctx) -> find_goal_in_ctx (proof_constr_intro jgmt incproof) ctx
   | PC_ApplyRight (jgmt, lproof, rctx) -> find_goal_in_ctx (proof_apply jgmt lproof incproof) rctx
   | PC_ApplyLeft (jgmt, lctx, rproof) -> find_goal_in_ctx (proof_apply jgmt incproof rproof) lctx
-  | PC_SpecializeAtom (jgmt, a, ctx) -> find_goal_in_ctx (proof_specialize jgmt a incproof) ctx
+  | PC_SpecializeAtom (jgmt, a, ctx) -> find_goal_in_ctx (proof_specialize_atom jgmt a incproof) ctx
+  | PC_SpecializeTerm (jgmt, t, ctx) -> find_goal_in_ctx (proof_specialize_term jgmt t incproof) ctx
   | PC_ExFalso (jgmt, ctx) -> find_goal_in_ctx (proof_ex_falso jgmt incproof) ctx
 
 (** [destruct_impl c f] is

--- a/lib/Prover/ProverInternals.ml
+++ b/lib/Prover/ProverInternals.ml
@@ -35,6 +35,7 @@ and find_goal_in_ctx incproof = function
   | PC_ConstrIntro (jgmt, ctx) -> find_goal_in_ctx (proof_constr_intro jgmt incproof) ctx
   | PC_ApplyRight (jgmt, lproof, rctx) -> find_goal_in_ctx (proof_apply jgmt lproof incproof) rctx
   | PC_ApplyLeft (jgmt, lctx, rproof) -> find_goal_in_ctx (proof_apply jgmt incproof rproof) lctx
+  | PC_SpecifyAtom (jgmt, a, ctx) -> find_goal_in_ctx (proof_specify jgmt a incproof) ctx
   | PC_ExFalso (jgmt, ctx) -> find_goal_in_ctx (proof_ex_falso jgmt incproof) ctx
 
 (** [destruct_impl c f] is

--- a/lib/Prover/ProverInternals.ml
+++ b/lib/Prover/ProverInternals.ml
@@ -35,7 +35,7 @@ and find_goal_in_ctx incproof = function
   | PC_ConstrIntro (jgmt, ctx) -> find_goal_in_ctx (proof_constr_intro jgmt incproof) ctx
   | PC_ApplyRight (jgmt, lproof, rctx) -> find_goal_in_ctx (proof_apply jgmt lproof incproof) rctx
   | PC_ApplyLeft (jgmt, lctx, rproof) -> find_goal_in_ctx (proof_apply jgmt incproof rproof) lctx
-  | PC_SpecifyAtom (jgmt, a, ctx) -> find_goal_in_ctx (proof_specify jgmt a incproof) ctx
+  | PC_SpecializeAtom (jgmt, a, ctx) -> find_goal_in_ctx (proof_specialize jgmt a incproof) ctx
   | PC_ExFalso (jgmt, ctx) -> find_goal_in_ctx (proof_ex_falso jgmt incproof) ctx
 
 (** [destruct_impl c f] is

--- a/lib/Prover/Tactics.ml
+++ b/lib/Prover/Tactics.ml
@@ -15,7 +15,7 @@ let try_tactic tactic state = state |> try_tactic' (const state) tactic
 
 let try_opt tactic = try_tactic' (const none) (some % tactic)
 
-let intros = flip (List.fold_left (flip intro))
+let intros = flip (List.fold_left (flip intro_named))
 
 let try_many on_fail tactics state =
   match List.find_map (flip try_opt state) tactics with
@@ -24,7 +24,7 @@ let try_many on_fail tactics state =
 
 let add_assumption h_name h state =
   let _, f = goal state in
-  state |> apply (F_Impl (h, f)) |> intro h_name
+  state |> apply (F_Impl (h, f)) |> intro_named h_name
 
 let add_assumption_parse h_name h_string state =
   let env, _ = goal state in
@@ -33,7 +33,7 @@ let add_assumption_parse h_name h_string state =
 
 let add_constr c state =
   let _, f = goal state in
-  state |> apply (F_ConstrImpl (c, f)) |> intro_constr
+  state |> apply (F_ConstrImpl (c, f)) |> intro
 
 let add_constr_parse c_string state =
   let env, _ = goal state in
@@ -62,7 +62,7 @@ let rec repeat tactic state =
 
 let trivial =
   let on_fail _ = raise $ ProofException "This ain't trivial" in
-  try_many on_fail [intro "_" %> assumption; assumption; truth; intro_constr]
+  try_many on_fail [intro_named "_" %> assumption; assumption; truth; intro]
 
 let apply_parse f_string state =
   let env, _ = goal state in

--- a/lib/Substitution.ml
+++ b/lib/Substitution.ml
@@ -110,3 +110,7 @@ let rec subst_var_in_shape x s = function
   | S_Lam s' -> S_Lam (subst_var_in_shape x s s')
   | S_App (s1, s2) -> S_App (subst_var_in_shape x s s1, subst_var_in_shape x s s2)
   | (S_Var _ | S_Atom | S_Fun _) as s -> s
+
+let ( |-> ) a b = subst_atom_in_formula a b
+
+let ( |=> ) x t = subst_var_in_formula x t

--- a/lib/Substitution.mli
+++ b/lib/Substitution.mli
@@ -17,6 +17,10 @@ val subst_var_in_kind : var -> term -> kind -> kind
 
 val subst_atom_in_formula : atom -> atom -> formula -> formula
 
+val ( |-> ) : atom -> atom -> formula -> formula
+
 val subst_var_in_formula : var -> term -> formula -> formula
+
+val ( |=> ) : var -> term -> formula -> formula
 
 val subst_var_in_shape : var -> shape -> shape -> shape

--- a/lib/Types.ml
+++ b/lib/Types.ml
@@ -72,4 +72,6 @@ type formula =
 
 type identifier_kind = K_Atom | K_Var | K_FVar of int * kind
 
-type identifier_env = (string * identifier_kind) list
+type identifier = string * identifier_kind
+
+type identifier_env = identifier list

--- a/lib/Types.mli
+++ b/lib/Types.mli
@@ -87,4 +87,6 @@ type formula =
 (** [FVar]s are represented by [int]s and have [kind]s*)
 type identifier_kind = K_Atom | K_Var | K_FVar of int * kind
 
-type identifier_env = (string * identifier_kind) list
+type identifier = string * identifier_kind
+
+type identifier_env = identifier list

--- a/lib/Utils.ml
+++ b/lib/Utils.ml
@@ -1,6 +1,7 @@
 open Common
 open Substitution
 open Types
+open Permutation
 
 let fix_kind x y k =
   (*  G, X : (forall y, [y < x] => K{y/x}) |- F : K  *)
@@ -15,3 +16,47 @@ let fix_binder fix_name fix_rep x y k =
 let fix fix_name fix_rep x y k f =
   let fix = fix_binder fix_name fix_rep x y k in
   F_Fix (fix, x, k, f)
+
+let merge_names xs ys = List.merge compare xs ys
+
+let rec free_names_of_permutation perm =
+  List.fold_left (fun acc -> merge_names acc % free_names_of_swap) [] perm
+
+and free_names_of_permuted {perm; symb= A a} = merge_names [a] (free_names_of_permutation perm)
+
+and free_names_of_swap (a1, a2) =
+  merge_names (free_names_of_permuted a1) (free_names_of_permuted a2)
+
+let rec free_names_of_term = function
+  | T_App (t1, t2)               -> merge_names (free_names_of_term t1) (free_names_of_term t2)
+  | T_Lam ({perm; symb= A a}, t) ->
+      List.filter (not % ( = ) a)
+      $ merge_names (free_names_of_permutation perm) (free_names_of_term t)
+  | T_Var {perm; symb= V x}      -> merge_names [x] (free_names_of_permutation perm)
+  | T_Atom {perm; symb= A a}     -> merge_names [a] (free_names_of_permutation perm)
+  | T_Fun _                      -> []
+
+let free_names_of_constr = function
+  | C_Fresh (A a, t) -> merge_names [a] (free_names_of_term t)
+  | C_AtomEq (A a1, a2) | C_AtomNeq (A a1, a2) -> merge_names [a1] (free_names_of_term (T_Atom a2))
+  | C_Eq (t1, t2) | C_Shape (t1, t2) | C_Subshape (t1, t2) ->
+      merge_names (free_names_of_term t1) (free_names_of_term t2)
+
+let rec free_names_of_formula = function
+  | F_Bot | F_Top | F_Var _ -> []
+  | F_App (f1, f2) | F_Impl (f1, f2) ->
+      merge_names (free_names_of_formula f1) (free_names_of_formula f2)
+  | F_Or fs | F_And fs -> List.fold_left (fun acc -> merge_names acc % free_names_of_formula) [] fs
+  | F_Constr c -> free_names_of_constr c
+  | F_ConstrAnd (c, f) | F_ConstrImpl (c, f) ->
+      merge_names (free_names_of_constr c) (free_names_of_formula f)
+  | F_AppAtom (f, A a) -> merge_names [a] (free_names_of_formula f)
+  | F_AppTerm (f, t) -> merge_names (free_names_of_term t) (free_names_of_formula f)
+  | F_FunAtom (A name, f)
+  | F_FunTerm (V name, f)
+  | F_ForallAtom (A name, f)
+  | F_ForallTerm (V name, f)
+  | F_ExistsAtom (A name, f)
+  | F_ExistsTerm (V name, f)
+  | F_Fix (_, V name, _, f) -> List.filter (not % ( = ) name) (free_names_of_formula f)
+  | F_Fun (_, f) -> free_names_of_formula f

--- a/lib/Utils.mli
+++ b/lib/Utils.mli
@@ -10,3 +10,7 @@ val fix_binder : string -> int -> var -> var -> kind -> fvar_binder
 val fix : string -> int -> var -> var -> kind -> formula -> formula
 (** [fix fix_name fix_rep x y k] returns [F_Fix(fix, x, k, k) = `fix x(fix_name) in f:k`]
     where [fix = fix_binder fix_name fix_rep x y k] *)
+
+val free_names_of_formula : formula -> string list
+
+val free_names_of_constr : constr -> string list

--- a/test/Prover.ml
+++ b/test/Prover.ml
@@ -21,23 +21,25 @@ let th1 =
   let env1 = fvars_env [("p", K_Prop); ("q", K_Prop)] in
   (env env1 [] [], parse_formula_in_env env1 "(p => q) => p => q")
 
-let proof1 th1 = proof' th1 |> intro "HPQ" |> intro "HP" |> apply_assm "HPQ" |> apply_assm "HP"
+let proof1 th1 = proof' th1 |> intros ["HPQ"; "HP"] |> apply_assm "HPQ" |> apply_assm "HP"
 
 let th2 =
   let env2 = fvars_env [("p", K_Prop); ("q", K_Prop); ("r", K_Prop)] in
   (env env2 [] [], parse_formula_in_env env2 "(p => q => r) => (p => q) => p => r")
 
 let proof2 th2 =
-  proof' th2 |> intro "HPQR" |> intro "HPQ" |> intro "HP" |> apply_assm "HPQR" |> assumption
-  |> apply_assm "HPQ" |> apply_assm "HP"
+  proof' th2
+  |> intros ["HPQR"; "HPQ"; "HP"]
+  |> apply_assm "HPQR" |> assumption |> apply_assm "HPQ" |> apply_assm "HP"
 
 let th3 =
   let env3 = fvars_env [("p", K_Prop)] in
   (env env3 [] [], parse_formula_in_env env3 "(((p => ⊥) => p) => p) => ((p => ⊥) => ⊥) => p")
 
 let proof3 th3 =
-  proof' th3 |> intro "H1" |> intro "H2" |> apply_assm "H1" |> intro "H3" |> ex_falso
-  |> apply_assm "H2" |> apply_assm "H3"
+  proof' th3
+  |> intros ["H1"; "H2"]
+  |> apply_assm "H1" |> intros ["H3"] |> ex_falso |> apply_assm "H2" |> apply_assm "H3"
 
 let th4 =
   let env4 = fvars_env [("p", K_Prop)] in
@@ -46,7 +48,7 @@ let th4 =
 let proof4 th4 =
   proof' th4
   |> intros ["H1"; "H2"]
-  |> apply_assm "H1" |> intro "H3"
+  |> apply_assm "H1" |> intros ["H3"]
   |> apply_parse "(p => ⊥) => p => ⊥" %> trivial
   |> assumption |> apply_assm "H2" |> assumption
 
@@ -54,16 +56,20 @@ let th5 =
   let env5 = atoms_env ["a"; "b"; "c"] in
   (env env5 [] [], parse_formula_in_env env5 "[a = b] => [c =/= b] => [a # c]")
 
-let proof5 th5 = proof' th5 |> repeat intro_constr |> by_solver
+let proof5 th5 = proof' th5 |> repeat intro |> by_solver
 
 let th6 =
   let env6 = atoms_env ["a"; "b"; "c"] in
   (env env6 [] [], parse_formula_in_env env6 "([a = b] => (a # c)) => [a = b] => (c =/= b)")
 
 let proof6 th6 =
-  proof' th6 |> intro "H" |> intro_constr
+  proof' th6 |> intros ["H"] |> intro
   |> add_constr_parse "a # c" %> by_solver
   |> apply_assm "H" %> by_solver
+
+let th7 = (empty, parse_formula "forall a : atom. forall b : atom. [a =/= b] => [a # b]")
+
+let proof7 th7 = proof' th7 |> repeat intro |> by_solver
 
 let _ = test_proof th1 proof1
 
@@ -76,5 +82,7 @@ let _ = test_proof th4 proof4
 let _ = test_proof th5 proof5
 
 let _ = test_proof th6 proof6
+
+let _ = test_proof th7 proof7
 
 let _ = print_newline ()

--- a/test/Prover.ml
+++ b/test/Prover.ml
@@ -72,12 +72,13 @@ let th7 = (empty, parse_formula "forall a : atom. forall b : atom. [a =/= b] => 
 let proof7 th7 = proof' th7 |> repeat intro |> by_solver
 
 let th8 =
-  let env8 = atoms_env ["c"; "d"] in
+  let env8 = atoms_env ["b"; "c"] @ vars_env ["y"] in
   ( env env8 [] []
   , parse_formula_in_env env8
-      "(forall a : atom. forall b : atom. [a = b] => [a.a = a.b]) => [c = d] => [c.c = c.d]" )
+  "(forall a : atom. forall x : term. [a = x] => [a.a = a.x]) => [c = b.[b c]y] => [c.c = c.b.[b c] y]" [@ocamlformat "disable"]
+  )
 
-let proof8 th8 = proof' th8 |> intro_named "H" |> generalize "d" |> generalize "c" |> apply_assm "H"
+let proof8 th8 = proof' th8 |> intros ["H"] |> apply_assm_specialized "H" ["c"; "b. [b c]y"]
 
 let _ = test_proof th1 proof1
 

--- a/test/Prover.ml
+++ b/test/Prover.ml
@@ -71,6 +71,14 @@ let th7 = (empty, parse_formula "forall a : atom. forall b : atom. [a =/= b] => 
 
 let proof7 th7 = proof' th7 |> repeat intro |> by_solver
 
+let th8 =
+  let env8 = atoms_env ["c"; "d"] in
+  ( env env8 [] []
+  , parse_formula_in_env env8
+      "(forall a : atom. forall b : atom. [a = b] => [a.a = a.b]) => [c = d] => [c.c = c.d]" )
+
+let proof8 th8 = proof' th8 |> intro_named "H" |> generalize "d" |> generalize "c" |> apply_assm "H"
+
 let _ = test_proof th1 proof1
 
 let _ = test_proof th2 proof2
@@ -84,5 +92,7 @@ let _ = test_proof th5 proof5
 let _ = test_proof th6 proof6
 
 let _ = test_proof th7 proof7
+
+let _ = test_proof th8 proof8
 
 let _ = print_newline ()


### PR DESCRIPTION
Prover:
* `intro` can now go under forall quantifiers
* Add `apply_assm_specialized` that allows to feed arguments into assumptions 
* Add `generalize` for generalizing bound variable

Proof:
* Add `forall_atom_i` & `forall_atom_e`
* Add `forall_term_i` & `forall_term_e`
* Add (incomplete) implementation of `equiv` function
* Make `proof` and `incproof` types `private`