### PR TITLE
Add existential quantification to prover

### DIFF
--- a/lib/Proof/Proof.ml
+++ b/lib/Proof/Proof.ml
@@ -124,14 +124,6 @@ let exists_atom_i (A a_name as a) b f_a p =
       ((env |> remove_identifier a_name |> remove_assumption f_a, F_ExistsAtom (a, f_a)), b, p)
   else raise $ formula_mismatch f f'
 
-let exists_atom_e p_exists p =
-  let env, f = judgement p in
-  match judgement p_exists with
-  | env_a, F_ExistsAtom (A a, f_a) ->
-      let env = union env env_a |> remove_identifier a |> remove_assumption f_a in
-      P_Witness ((env, f), p_exists, p)
-  | _, g                           -> raise $ not_an_exists g
-
 let exists_term_i (V x_name as x) t f_x p =
   let f = (x |=> t) f_x in
   let env, f' = judgement p in
@@ -140,10 +132,10 @@ let exists_term_i (V x_name as x) t f_x p =
       ((env |> remove_identifier x_name |> remove_assumption f_x, F_ExistsTerm (x, f_x)), t, p)
   else raise $ formula_mismatch f f'
 
-let exists_term_e p_exists p =
+let exist_e p_exists p =
   let env, f = judgement p in
   match judgement p_exists with
-  | env_x, F_ExistsTerm (V x, f_x) ->
+  | env_x, F_ExistsAtom (A x, f_x) | env_x, F_ExistsTerm (V x, f_x) ->
       let env = union env env_x |> remove_identifier x |> remove_assumption f_x in
       P_Witness ((env, f), p_exists, p)
-  | _, g                           -> raise $ not_an_exists g
+  | _, g -> raise $ not_an_exists g

--- a/lib/Proof/Proof.mli
+++ b/lib/Proof/Proof.mli
@@ -14,6 +14,7 @@ type proof = private
   | P_SpecializeAtom of judgement * atom * proof
   | P_SpecializeTerm of judgement * term * proof
   | P_ExistsAtom     of judgement * atom * proof
+  | P_ExistsTerm     of judgement * term * proof
   | P_Witness        of judgement * proof * proof
   | P_ExFalso        of judgement * proof
 
@@ -49,3 +50,8 @@ val exists_atom_i : atom -> atom -> formula -> proof -> proof
 (** [exists_atom_i a b f p] is a proof of [exists a : atom. f] where [b] is the witness and [p] is proof of [(a |-> b) f]*)
 
 val exists_atom_e : proof -> proof -> proof
+
+val exists_term_i : var -> term -> formula -> proof -> proof
+(** [exists_term_i x t f p] is a proof of [exists x : term. f] where [t] is the witness and [p] is proof of [(x |=> t) f]*)
+
+val exists_term_e : proof -> proof -> proof

--- a/lib/Proof/Proof.mli
+++ b/lib/Proof/Proof.mli
@@ -13,6 +13,8 @@ type proof = private
   | P_ConstrApply    of judgement * proof * proof
   | P_SpecializeAtom of judgement * atom * proof
   | P_SpecializeTerm of judgement * term * proof
+  | P_ExistsAtom     of judgement * atom * proof
+  | P_Witness        of judgement * proof * proof
   | P_ExFalso        of judgement * proof
 
 val label : proof -> formula
@@ -42,3 +44,8 @@ val forall_atom_e : atom -> proof -> proof
 val forall_term_i : var -> proof -> proof
 
 val forall_term_e : term -> proof -> proof
+
+val exists_atom_i : atom -> atom -> formula -> proof -> proof
+(** [exists_atom_i a b f p] is a proof of [exists a : atom. f] where [b] is the witness and [p] is proof of [(a |-> b) f]*)
+
+val exists_atom_e : proof -> proof -> proof

--- a/lib/Proof/Proof.mli
+++ b/lib/Proof/Proof.mli
@@ -13,8 +13,6 @@ type proof = private
   | P_ConstrApply    of judgement * proof * proof
   | P_SpecializeAtom of judgement * atom * proof
   | P_SpecializeTerm of judgement * term * proof
-  | P_ExistsAtom     of judgement * atom * proof
-  | P_ExistsTerm     of judgement * term * proof
   | P_Witness        of judgement * proof * proof
   | P_ExFalso        of judgement * proof
 

--- a/lib/Proof/Proof.mli
+++ b/lib/Proof/Proof.mli
@@ -49,9 +49,7 @@ val forall_term_e : term -> proof -> proof
 val exists_atom_i : atom -> atom -> formula -> proof -> proof
 (** [exists_atom_i a b f p] is a proof of [exists a : atom. f] where [b] is the witness and [p] is proof of [(a |-> b) f]*)
 
-val exists_atom_e : proof -> proof -> proof
-
 val exists_term_i : var -> term -> formula -> proof -> proof
 (** [exists_term_i x t f p] is a proof of [exists x : term. f] where [t] is the witness and [p] is proof of [(x |=> t) f]*)
 
-val exists_term_e : proof -> proof -> proof
+val exist_e : proof -> proof -> proof

--- a/lib/Proof/ProofCommon.ml
+++ b/lib/Proof/ProofCommon.ml
@@ -41,7 +41,7 @@ let rec equiv f1 f2 =
   | F_ForallTerm (x1, f1), F_ForallTerm (x2, f2) | F_ExistsTerm (x1, f1), F_ExistsTerm (x2, f2) ->
       let x = var (fresh_var ()) in
       (x1 |=> x) f1 === (x2 |=> x) f2
-  | F_ForallAtom _, _ -> false
+  | F_ForallAtom _, _ | F_ForallTerm _, _ | F_ExistsAtom _, _ | F_ExistsTerm _, _ -> false
   | _ ->
       failwith
       $ Printf.sprintf "unimplemented: %s === %s" (Printing.string_of_formula f1)

--- a/lib/Proof/ProofCommon.ml
+++ b/lib/Proof/ProofCommon.ml
@@ -35,10 +35,10 @@ let rec equiv f1 f2 =
   | F_ConstrImpl _, _ -> false
   | F_Impl (f1, f1'), F_Impl (f2, f2') -> f1 === f2 && f1' === f2'
   | F_Impl _, _ -> false
-  | F_ForallAtom (a1, f1), F_ForallAtom (a2, f2) ->
+  | F_ForallAtom (a1, f1), F_ForallAtom (a2, f2) | F_ExistsAtom (a1, f1), F_ExistsAtom (a2, f2) ->
       let a = fresh_atom () in
       (a1 |-> a) f1 === (a2 |-> a) f2
-  | F_ForallTerm (x1, f1), F_ForallTerm (x2, f2) ->
+  | F_ForallTerm (x1, f1), F_ForallTerm (x2, f2) | F_ExistsTerm (x1, f1), F_ExistsTerm (x2, f2) ->
       let x = var (fresh_var ()) in
       (x1 |=> x) f1 === (x2 |=> x) f2
   | F_ForallAtom _, _ -> false

--- a/lib/Proof/ProofEnv.ml
+++ b/lib/Proof/ProofEnv.ml
@@ -45,7 +45,7 @@ let add_atom a = on_identifiers $ merge [(a, K_Atom)]
 
 let add_var x = on_identifiers $ merge [(x, K_Var)]
 
-let add_constr constr = on_constraints (List.cons constr)
+let add_constr constr = on_constraints $ merge [constr]
 
 let add_assumption ass = on_assumptions $ merge [ass]
 

--- a/lib/Proof/ProofException.ml
+++ b/lib/Proof/ProofException.ml
@@ -27,6 +27,8 @@ let not_a_constraint = not_what_expected "a constraint" % string_of_formula
 
 let not_a_forall = not_what_expected "an universal quantification" % string_of_formula
 
+let not_an_exists = not_what_expected "an existential quantification" % string_of_formula
+
 let premise_mismatch hypothesis premise =
   not_what_expected
     ("implication with premise " ^ string_of_formula premise)

--- a/lib/Prover/IncProof.ml
+++ b/lib/Prover/IncProof.ml
@@ -144,7 +144,7 @@ and proof_exists_term jgmt witness witness_proof =
 
 and proof_witness jgmt exists_proof usage_proof =
   match (normalize exists_proof, normalize usage_proof) with
-  | PI_Proven exists_proof, PI_Proven usage_proof -> proven $ exists_atom_e exists_proof usage_proof
+  | PI_Proven exists_proof, PI_Proven usage_proof -> proven $ exist_e exists_proof usage_proof
   | exists_proof, usage_proof -> PI_Witness (jgmt, exists_proof, usage_proof)
 
 let proof_case map_proof map_incproof incproof =

--- a/lib/Prover/Prover.ml
+++ b/lib/Prover/Prover.ml
@@ -131,3 +131,20 @@ let exists witness state =
       let context = PC_ExistsTerm (to_judgement (env, f), t, context state) in
       unfinished (env, (x |=> t) f_x) context
   | f                          -> raise $ not_an_exists f
+
+let remove_assumption_by_name name = remove_assumptions (( = ) name % fst)
+
+let destruct_assm h_name state =
+  let env, f = goal state in
+  let h_proof = assm_proof h_name env in
+  let env = env |> remove_assumption_by_name h_name in
+  match label' h_proof with
+  | F_ExistsAtom (A a, h_a) ->
+      let context = PC_WitnessUsage (to_judgement (env, f), h_proof, context state) in
+      let env = env |> add_atom a |> add_assumption (h_name, h_a) in
+      unfinished (env, f) context
+  | F_ExistsTerm (V x, h_x) ->
+      let context = PC_WitnessUsage (to_judgement (env, f), h_proof, context state) in
+      let env = env |> add_atom x |> add_assumption (h_name, h_x) in
+      unfinished (env, f) context
+  | f                       -> raise $ not_an_exists f

--- a/lib/Prover/Prover.ml
+++ b/lib/Prover/Prover.ml
@@ -126,4 +126,8 @@ let exists witness state =
       let b = parse_atom_in_env (identifiers env) witness in
       let context = PC_ExistsAtom (to_judgement (env, f), b, context state) in
       unfinished (env, (a |-> b) f_a) context
+  | F_ExistsTerm (x, f_x) as f ->
+      let t = parse_term_in_env (identifiers env) witness in
+      let context = PC_ExistsTerm (to_judgement (env, f), t, context state) in
+      unfinished (env, (x |=> t) f_x) context
   | f                          -> raise $ not_an_exists f

--- a/lib/Prover/Prover.ml
+++ b/lib/Prover/Prover.ml
@@ -118,3 +118,12 @@ let generalize name state =
       unfinished (env |> remove_identifier x, F_ForallTerm (V x, f)) context
   | Some (_x, K_FVar _) -> raise $ ProofException "Logical variables cannot be generalized"
   | None                -> raise $ unbound_variable name
+
+let exists witness state =
+  let env = goal_env state in
+  match goal_formula state with
+  | F_ExistsAtom (a, f_a) as f ->
+      let b = parse_atom_in_env (identifiers env) witness in
+      let context = PC_ExistsAtom (to_judgement (env, f), b, context state) in
+      unfinished (env, (a |-> b) f_a) context
+  | f                          -> raise $ not_an_exists f

--- a/lib/Prover/Prover.ml
+++ b/lib/Prover/Prover.ml
@@ -132,19 +132,16 @@ let exists witness state =
       unfinished (env, (x |=> t) f_x) context
   | f                          -> raise $ not_an_exists f
 
-let remove_assumption_by_name name = remove_assumptions (( = ) name % fst)
+let remove_assm name = remove_assumptions (( = ) name % fst)
 
 let destruct_assm h_name state =
   let env, f = goal state in
   let h_proof = assm_proof h_name env in
-  let env = env |> remove_assumption_by_name h_name in
-  match label' h_proof with
-  | F_ExistsAtom (A a, h_a) ->
-      let context = PC_WitnessUsage (to_judgement (env, f), h_proof, context state) in
-      let env = env |> add_atom a |> add_assumption (h_name, h_a) in
-      unfinished (env, f) context
-  | F_ExistsTerm (V x, h_x) ->
-      let context = PC_WitnessUsage (to_judgement (env, f), h_proof, context state) in
-      let env = env |> add_atom x |> add_assumption (h_name, h_x) in
-      unfinished (env, f) context
-  | f                       -> raise $ not_an_exists f
+  let context = PC_WitnessUsage (to_judgement (env, f), h_proof, context state) in
+  let update =
+    match label' h_proof with
+    | F_ExistsAtom (A a, h_a) -> remove_assm h_name %> add_assumption (h_name, h_a) %> add_atom a
+    | F_ExistsTerm (V x, h_x) -> remove_assm h_name %> add_assumption (h_name, h_x) %> add_var x
+    | f                       -> raise $ not_an_exists f
+  in
+  unfinished (update env, f) context

--- a/lib/Prover/Prover.mli
+++ b/lib/Prover/Prover.mli
@@ -28,3 +28,5 @@ val qed : prover_state -> proof
 val generalize : string -> tactic
 
 val exists : string -> tactic
+
+val destruct_assm : string -> tactic

--- a/lib/Prover/Prover.mli
+++ b/lib/Prover/Prover.mli
@@ -26,3 +26,5 @@ val truth : tactic
 val qed : prover_state -> proof
 
 val generalize : string -> tactic
+
+val exists : string -> tactic

--- a/lib/Prover/ProverInternals.ml
+++ b/lib/Prover/ProverInternals.ml
@@ -37,7 +37,10 @@ and find_goal_in_ctx incproof = function
   | PC_ApplyLeft (jgmt, lctx, rproof) -> find_goal_in_ctx (proof_apply jgmt incproof rproof) lctx
   | PC_SpecializeAtom (jgmt, a, ctx) -> find_goal_in_ctx (proof_specialize_atom jgmt a incproof) ctx
   | PC_SpecializeTerm (jgmt, t, ctx) -> find_goal_in_ctx (proof_specialize_term jgmt t incproof) ctx
-  | PC_ExistsAtom (jgmt, witness, ctx) -> find_goal_in_ctx (proof_exists jgmt witness incproof) ctx
+  | PC_ExistsAtom (jgmt, witness, ctx) ->
+      find_goal_in_ctx (proof_exists_atom jgmt witness incproof) ctx
+  | PC_ExistsTerm (jgmt, witness, ctx) ->
+      find_goal_in_ctx (proof_exists_term jgmt witness incproof) ctx
   | PC_WitnessExists (jgmt, ctx, usage_proof) ->
       find_goal_in_ctx (proof_witness jgmt incproof usage_proof) ctx
   | PC_WitnessUsage (jgmt, exists_proof, ctx) ->

--- a/lib/Prover/ProverInternals.ml
+++ b/lib/Prover/ProverInternals.ml
@@ -37,6 +37,11 @@ and find_goal_in_ctx incproof = function
   | PC_ApplyLeft (jgmt, lctx, rproof) -> find_goal_in_ctx (proof_apply jgmt incproof rproof) lctx
   | PC_SpecializeAtom (jgmt, a, ctx) -> find_goal_in_ctx (proof_specialize_atom jgmt a incproof) ctx
   | PC_SpecializeTerm (jgmt, t, ctx) -> find_goal_in_ctx (proof_specialize_term jgmt t incproof) ctx
+  | PC_ExistsAtom (jgmt, witness, ctx) -> find_goal_in_ctx (proof_exists jgmt witness incproof) ctx
+  | PC_WitnessExists (jgmt, ctx, usage_proof) ->
+      find_goal_in_ctx (proof_witness jgmt incproof usage_proof) ctx
+  | PC_WitnessUsage (jgmt, exists_proof, ctx) ->
+      find_goal_in_ctx (proof_witness jgmt exists_proof incproof) ctx
   | PC_ExFalso (jgmt, ctx) -> find_goal_in_ctx (proof_ex_falso jgmt incproof) ctx
 
 (** [destruct_impl c f] is

--- a/test/Prover.ml
+++ b/test/Prover.ml
@@ -80,6 +80,12 @@ let th8 =
 
 let proof8 th8 = proof' th8 |> intros ["H"] |> apply_assm_specialized "H" ["c"; "b. [b c]y"]
 
+let th9 =
+  let env9 = atoms_env ["c"; "d"] in
+  (env env9 [] [], parse_formula_in_env env9 "[c # d] => exists a:atom. exists b:atom. [a =/= b]")
+
+let proof9 th9 = proof' th9 |> intro |> exists "d" |> exists "c" |> by_solver
+
 let _ = test_proof th1 proof1
 
 let _ = test_proof th2 proof2
@@ -95,5 +101,7 @@ let _ = test_proof th6 proof6
 let _ = test_proof th7 proof7
 
 let _ = test_proof th8 proof8
+
+let _ = test_proof th9 proof9
 
 let _ = print_newline ()

--- a/test/Prover.ml
+++ b/test/Prover.ml
@@ -86,6 +86,22 @@ let th9 =
 
 let proof9 th9 = proof' th9 |> intro |> exists "d" |> exists "c" |> by_solver
 
+let th10 =
+  (empty, parse_formula "forall a : atom. (exists b: atom. [a =/= b]) => exists t:term. a # t")
+
+let proof10 th10 =
+  proof' th10 |> intro |> intros ["H"] |> destruct_assm "H" |> exists "b" |> by_solver
+
+let th11 =
+  ( empty
+  , parse_formula
+      "(forall a : atom. exists b: atom. [a =/= b]) => (forall a:atom. exists t:term. a # t)" )
+
+let proof11 th11 =
+  proof' th11 |> intros ["H"] |> intro
+  |> add_assumption_parse "Hc" "exists c:atom. a =/= c"
+  |> destruct_assm "Hc" |> exists "c" |> by_solver |> apply_assm_specialized "H" ["a"]
+
 let _ = test_proof th1 proof1
 
 let _ = test_proof th2 proof2
@@ -103,5 +119,9 @@ let _ = test_proof th7 proof7
 let _ = test_proof th8 proof8
 
 let _ = test_proof th9 proof9
+
+let _ = test_proof th10 proof10
+
+let _ = test_proof th11 proof11
 
 let _ = print_newline ()


### PR DESCRIPTION
Proof:
* add `exists_atom_i`, `exists_term_i`, `exists_e`
* fix bug with constraints excaping their scope

Prover:
* add `exists` tactic
* add `destruct_assm` tactic allowing user to use assumptions of existential quantification