### PR TITLE
Add conjunction and discjunction to Prover

### DIFF
--- a/lib/Proof/Proof.mli
+++ b/lib/Proof/Proof.mli
@@ -13,6 +13,9 @@ type proof = private
   | P_SpecializeAtom of judgement * atom * proof
   | P_SpecializeTerm of judgement * term * proof
   | P_Witness        of judgement * proof * proof
+  | P_AndIntro       of judgement * proof list
+  | P_AndElim        of judgement * proof
+  | P_OrElim         of judgement * proof list
   | P_ExFalso        of judgement * proof
 
 val label : proof -> formula
@@ -50,3 +53,11 @@ val exists_term_i : var -> term -> formula -> proof -> proof
 (** [exists_term_i x t f p] is a proof of [exists x : term. f] where [t] is the witness and [p] is proof of [(x |=> t) f]*)
 
 val exist_e : proof -> proof -> proof
+
+val and_i : proof list -> proof
+
+val and_e : formula -> proof -> proof
+
+val or_i : formula list -> proof -> proof
+
+val or_e : proof -> proof list -> proof

--- a/lib/Proof/ProofCommon.ml
+++ b/lib/Proof/ProofCommon.ml
@@ -21,6 +21,10 @@ let conclusion = function
   | F_Impl (_, c) | F_ConstrImpl (_, c) -> c
   | f -> raise $ not_an_implication f
 
+let disjuncts = function
+  | F_Or fs -> fs
+  | f       -> raise $ not_a_disjunction f
+
 let rec equiv f1 f2 =
   match (f1, f2) with
   | F_Top, F_Top | F_Bot, F_Bot -> true

--- a/lib/Proof/ProofException.ml
+++ b/lib/Proof/ProofException.ml
@@ -29,9 +29,24 @@ let not_a_forall = not_what_expected "an universal quantification" % string_of_f
 
 let not_an_exists = not_what_expected "an existential quantification" % string_of_formula
 
+let not_a_disjunction = not_what_expected "a disjunction" % string_of_formula
+
+let not_what_with what with_what = not_what_expected (Printf.sprintf "a %s with %s" what with_what)
+
+let not_a_conjunction_with conjunct =
+  not_what_with "a conjunction" (string_of_formula conjunct) % string_of_formula
+
+let not_a_disjunction_with disjunct =
+  not_what_with "a disjunction" (string_of_formula disjunct) % string_of_formula
+
 let premise_mismatch hypothesis premise =
   not_what_expected
     ("implication with premise " ^ string_of_formula premise)
+    (string_of_formula hypothesis)
+
+let conclusion_mismatch hypothesis conclusion =
+  not_what_expected
+    ("implication with conclusion " ^ string_of_formula conclusion)
     (string_of_formula hypothesis)
 
 let formula_mismatch expected actual =
@@ -54,4 +69,8 @@ let solver_failure constraints constr =
 let cannot_generalize name f =
   let f = string_of_formula f in
   let exn = Printf.sprintf "Cannot generalize %s as it is bound in %s" name f in
+  ProofException exn
+
+let cannot_destruct f =
+  let exn = Printf.sprintf "Cannot destruct %s" (string_of_formula f) in
   ProofException exn

--- a/lib/Prover/Prover.ml
+++ b/lib/Prover/Prover.ml
@@ -120,7 +120,7 @@ let destruct_assm_witness env f h_name h_proof h ctx =
   unfinished (env, f) ctx
 
 let destruct_assm_and env f h_name hs_proof hs ctx =
-  (* given goal [f] in contex [ctx] and [h] return goal [h => f] in proper contex *)
+  (* given [h] and current goal [f] (in context [ctx]) and return goal [h => f] in proper context *)
   let add_conjunct h (f, ctx) =
     let f = F_Impl (h, f) in
     let h_proof = proof_and_elim (to_judgement (env, h)) hs_proof in
@@ -133,7 +133,7 @@ let destruct_assm_and env f h_name hs_proof hs ctx =
 let destruct_assm_or env f h_name hs_proof hs ctx =
   let h_env = remove_assm h_name env in
   let hs_proofs = List.map (fun h -> proof_hole h_env $ F_Impl (h, f)) hs in
-  find_goal_in_ctx (proof_or_elim (to_judgement (env, f)) hs_proof hs_proofs) ctx
+  find_goal_in_proof ctx $ proof_or_elim (to_judgement (env, f)) hs_proof hs_proofs
 
 let destruct_assm h_name state =
   let env, f = goal state in
@@ -150,9 +150,10 @@ let destruct_goal state =
   let env, f = goal state in
   match f with
   | F_And fs ->
+      let ctx = context state in
       let jgmt = to_judgement (env, f) in
-      let holes = List.map (proof_hole env) fs in
-      find_goal_in_ctx (proof_and jgmt holes) (context state)
+      let goals = List.map (proof_hole env) fs in
+      find_goal_in_proof ctx $ proof_and jgmt goals
   | f        -> raise $ cannot_destruct f
 
 let destruct_goal' n state =

--- a/lib/Prover/Prover.mli
+++ b/lib/Prover/Prover.mli
@@ -30,3 +30,7 @@ val generalize : string -> tactic
 val exists : string -> tactic
 
 val destruct_assm : string -> tactic
+
+val destruct_goal : tactic
+
+val destruct_goal' : int -> tactic

--- a/lib/Prover/ProverInternals.ml
+++ b/lib/Prover/ProverInternals.ml
@@ -28,7 +28,7 @@ let rec find_goal_in_proof context incproof =
   | Either.Left (proof, context) -> find_goal_in_ctx (proven proof) context
   | Either.Right (goal, context) -> unfinished goal context
 
-(** Helper functions that given [incproof] and its [contex] builds appropriate [state] *)
+(** Helper functions that given [incproof] and its [context] builds appropriate [state] *)
 and find_goal_in_ctx incproof = function
   | PC_Root -> proof_case finished (find_goal_in_proof PC_Root) incproof
   | PC_Intro (jgmt, ctx) -> find_goal_in_ctx (proof_intro jgmt incproof) ctx

--- a/lib/Prover/ProverInternals.ml
+++ b/lib/Prover/ProverInternals.ml
@@ -44,6 +44,15 @@ and find_goal_in_ctx incproof = function
       find_goal_in_ctx (proof_witness jgmt incproof usage_proof) ctx
   | PC_WitnessUsage (jgmt, exists_proof, ctx) ->
       find_goal_in_ctx (proof_witness jgmt exists_proof incproof) ctx
+  | PC_And (jgmt, proofs, ctx) ->
+      let proofs = Zipper.to_list $ Zipper.insert incproof proofs in
+      find_goal_in_ctx (proof_and jgmt proofs) ctx
+  | PC_AndElim (jgmt, ctx) -> find_goal_in_ctx (proof_and_elim jgmt incproof) ctx
+  | PC_Or (jgmt, ctx) -> find_goal_in_ctx (proof_or jgmt incproof) ctx
+  | PC_OrElim (jgmt, ctx, proofs) -> find_goal_in_ctx (proof_or_elim jgmt incproof proofs) ctx
+  | PC_OrElimDiscjunt (jgmt, or_proof, proofs, ctx) ->
+      let proofs = Zipper.to_list $ Zipper.insert incproof proofs in
+      find_goal_in_ctx (proof_or_elim jgmt or_proof proofs) ctx
   | PC_ExFalso (jgmt, ctx) -> find_goal_in_ctx (proof_ex_falso jgmt incproof) ctx
 
 (** [destruct_impl c f] is

--- a/lib/Prover/ProverInternals.mli
+++ b/lib/Prover/ProverInternals.mli
@@ -8,6 +8,8 @@ type prover_state = S_Unfinished of {goal: goal; context: proof_context} | S_Fin
 
 type tactic = prover_state -> prover_state
 
+val find_goal_in_proof : proof_context -> incproof -> prover_state
+
 val find_goal_in_ctx : incproof -> proof_context -> prover_state
 
 val goal : prover_state -> goal

--- a/lib/Prover/Zipper.ml
+++ b/lib/Prover/Zipper.ml
@@ -1,4 +1,4 @@
-type 'a zipper = {left: 'a list; right: 'a list} (* right can be empty only if left is empty *)
+type 'a zipper = {left: 'a list; right: 'a list} (* right can only be empty if left is empty *)
 
 let from_list xs = {left= []; right= xs}
 
@@ -11,9 +11,9 @@ let is_empty {right; _} =
 
 let insert x {left; right} = {left; right= x :: right}
 
-let move_back {left; right} =
+let move_back_if_not_empty {left; right} =
   match left with
-  | []      -> failwith "move_back on leftmost"
+  | []      -> {left; right}
   | x :: xs -> {left= xs; right= x :: right}
 
 let move_forward {left; right} =
@@ -24,12 +24,13 @@ let move_forward {left; right} =
 let extract_current {left; right} =
   match right with
   | []      -> failwith "extract_current on empty"
+  | [x]     -> (x, move_back_if_not_empty {left; right= []})
   | x :: xs -> (x, {left; right= xs})
 
-let rec extract_first test ({left; right} as z) =
+let rec extract_first test ({right; _} as z) =
   match right with
   | [] -> None
-  | x :: xs when test x -> Some (x, {left; right= xs})
+  | x :: _ when test x -> Some (extract_current z)
   | _ -> extract_first test (move_forward z)
 
 let exists test {left; right} = List.exists test left || List.exists test right

--- a/lib/Prover/Zipper.ml
+++ b/lib/Prover/Zipper.ml
@@ -27,10 +27,10 @@ let extract_current {left; right} =
   | [x]     -> (x, move_back_if_not_empty {left; right= []})
   | x :: xs -> (x, {left; right= xs})
 
-let rec extract_first test ({right; _} as z) =
+let rec extract_next test ({right; _} as z) =
   match right with
   | [] -> None
   | x :: _ when test x -> Some (extract_current z)
-  | _ -> extract_first test (move_forward z)
+  | _ -> extract_next test (move_forward z)
 
 let exists test {left; right} = List.exists test left || List.exists test right

--- a/lib/Prover/Zipper.ml
+++ b/lib/Prover/Zipper.ml
@@ -1,0 +1,35 @@
+type 'a zipper = {left: 'a list; right: 'a list} (* right can be empty only if left is empty *)
+
+let from_list xs = {left= []; right= xs}
+
+let to_list {left; right} = List.rev_append left right
+
+let is_empty {right; _} =
+  match right with
+  | []     -> true
+  | _ :: _ -> false
+
+let insert x {left; right} = {left; right= x :: right}
+
+let move_back {left; right} =
+  match left with
+  | []      -> failwith "move_back on leftmost"
+  | x :: xs -> {left= xs; right= x :: right}
+
+let move_forward {left; right} =
+  match right with
+  | []      -> failwith "move_forward on rightmost"
+  | x :: xs -> {left= x :: left; right= xs}
+
+let extract_current {left; right} =
+  match right with
+  | []      -> failwith "extract_current on empty"
+  | x :: xs -> (x, {left; right= xs})
+
+let rec extract_first test ({left; right} as z) =
+  match right with
+  | [] -> None
+  | x :: xs when test x -> Some (x, {left; right= xs})
+  | _ -> extract_first test (move_forward z)
+
+let exists test {left; right} = List.exists test left || List.exists test right

--- a/test/Prover.ml
+++ b/test/Prover.ml
@@ -102,6 +102,27 @@ let proof11 th11 =
   |> add_assumption_parse "Hc" "exists c:atom. a =/= c"
   |> destruct_assm "Hc" |> exists "c" |> by_solver |> apply_assm_specialized "H" ["a"]
 
+let th12 =
+  let env12 = fvars_env [("p", K_Prop); ("q", K_Prop); ("r", K_Prop)] in
+  (env env12 [] [], parse_formula_in_env env12 "(p ∧ q ∧ r) => (q ∧ r ∧ p)")
+
+let proof12 = proof' %> intros ["H"] %> destruct_assm "H" %> destruct_goal %> repeat assumption
+
+let th13 =
+  let e13 = fvars_env [("p", K_Prop); ("q", K_Prop)] in
+  (env e13 [] [], parse_formula_in_env e13 "p => p ∨ q")
+
+let proof13 = proof' %> intros ["H"] %> destruct_goal' 0 %> apply_assm "H"
+
+let th14 =
+  let e14 = fvars_env [("p", K_Prop); ("q", K_Prop); ("r", K_Prop); ("s", K_Prop)] in
+  (env e14 [] [], parse_formula_in_env e14 "(p => s) => (q => s) => (r => s) => (p ∨ q ∨ r) => s")
+
+let proof14 =
+  proof'
+  %> intros ["Hp"; "Hq"; "Hr"; "H"]
+  %> destruct_assm "H" %> apply_assm "Hp" %> apply_assm "Hq" %> apply_assm "Hr"
+
 let _ = test_proof th1 proof1
 
 let _ = test_proof th2 proof2
@@ -123,5 +144,11 @@ let _ = test_proof th9 proof9
 let _ = test_proof th10 proof10
 
 let _ = test_proof th11 proof11
+
+let _ = test_proof th12 proof12
+
+let _ = test_proof th13 proof13
+
+let _ = test_proof th14 proof14
 
 let _ = print_newline ()


### PR DESCRIPTION
Proof:
* add `and_i`, `and_e`, `or_i`, `or_e`

Prover:
* add `destruct_goal`
* include conjunctions and disjunctions in `destruct_assm`
* add `'a zipper` type